### PR TITLE
Enable LZ4 support.

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -5,8 +5,8 @@ package rocksdb
 
 // #cgo CPPFLAGS: -Iinternal -Iinternal/include -Iinternal/db -Iinternal/util
 // #cgo CPPFLAGS: -Iinternal/utilities/merge_operators/string_append
-// #cgo CPPFLAGS: -I../c-snappy/internal
-// #cgo CPPFLAGS: -DROCKSDB_PLATFORM_POSIX -DNDEBUG -DSNAPPY
+// #cgo CPPFLAGS: -I../c-snappy/internal -I../c-lz4/internal/lib
+// #cgo CPPFLAGS: -DROCKSDB_PLATFORM_POSIX -DNDEBUG -DSNAPPY -DLZ4
 // #cgo darwin CPPFLAGS: -DOS_MACOSX
 // #cgo linux CPPFLAGS: -DOS_LINUX
 // #cgo CXXFLAGS: -Wall -Werror -Wsign-compare -Wshadow


### PR DESCRIPTION
LZ4 is supposed to be faster than Snappy.
