### PR TITLE
link in jemalloc

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -5,14 +5,15 @@ package rocksdb
 
 import (
 	// explicit because these Go libraries do not export any Go symbols.
+	_ "github.com/cockroachdb/c-jemalloc"
 	_ "github.com/cockroachdb/c-lz4"
 	_ "github.com/cockroachdb/c-snappy"
 )
 
 // #cgo CPPFLAGS: -Iinternal -Iinternal/include -Iinternal/db -Iinternal/util
 // #cgo CPPFLAGS: -Iinternal/utilities/merge_operators/string_append
-// #cgo CPPFLAGS: -I../c-snappy/internal -I../c-lz4/internal/lib
-// #cgo CPPFLAGS: -DROCKSDB_PLATFORM_POSIX -DNDEBUG -DSNAPPY -DLZ4
+// #cgo CPPFLAGS: -I../c-lz4/internal/lib -I../c-snappy/internal
+// #cgo CPPFLAGS: -DROCKSDB_PLATFORM_POSIX -DNDEBUG -DJEMALLOC -DLZ4 -DSNAPPY
 // #cgo darwin CPPFLAGS: -DOS_MACOSX
 // #cgo linux CPPFLAGS: -DOS_LINUX
 // #cgo freebsd CPPFLAGS: -DOS_FREEBSD


### PR DESCRIPTION
I tested this in the main cockroach binary by printing the stats at exit:

``` diff
diff --git a/main.go b/main.go
index 0c22b74..fd51773 100644
--- a/main.go
+++ b/main.go
@@ -24,10 +24,19 @@ import (
    "math/rand"
    "os"

+   _ "github.com/cockroachdb/c-jemalloc"
+
    "github.com/cockroachdb/cockroach/cli"
    "github.com/cockroachdb/cockroach/util/randutil"
 )

+// #cgo CPPFLAGS: -I../c-jemalloc/internal/include
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+//
+// #include <jemalloc/jemalloc.h>
+import "C"
+
 func main() {
    // Seed the math/rand RNG from crypto/rand.
    rand.Seed(randutil.NewPseudoSeed())
@@ -39,4 +48,6 @@ func main() {
        fmt.Fprintf(os.Stderr, "Failed running command %q: %v\n", os.Args[1:], err)
        os.Exit(1)
    }
+
+   C.malloc_stats_print(nil, nil, nil)
 }
```

Here are some results from the client and server after a short SQL session: https://gist.github.com/tamird/4dcdc6713ce8fb590cb2

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/c-rocksdb/11)

<!-- Reviewable:end -->
