### PR TITLE
Use user_comparator when comparing against iterate_upper_bound.

### DIFF
--- a/internal/db/db_iter.cc
+++ b/internal/db/db_iter.cc
@@ -216,7 +216,7 @@ void DBIter::FindNextUserEntryInternal(bool skipping) {
 
     if (ParseKey(&ikey)) {
       if (iterate_upper_bound_ != nullptr &&
-          ikey.user_key.compare(*iterate_upper_bound_) >= 0) {
+          user_comparator_->Compare(ikey.user_key, *iterate_upper_bound_) >= 0) {
         break;
       }
 


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/issues/983.
See https://github.com/facebook/rocksdb/pull/984.
