### PR TITLE
Use prefix_same_as_start to avoid iteration in FindNextUserEntryInternal.

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -6,6 +6,8 @@ rm -rf *.cc internal/*
 curl -sL https://github.com/facebook/rocksdb/archive/v4.3.1.tar.gz | tar zxf - -C internal --strip-components=1
 make -C internal util/build_version.cc
 patch -p1 < gitignore.patch
+patch -p1 < iterate-upper-bound.patch
+patch -p1 < prefix-same-as-start.patch
 
 # symlink so cgo compiles them
 for source_file in $(make sources | grep -vE '(/redis/|_(cmd|tool).cc$)'); do

--- a/internal/db/db_iter.cc
+++ b/internal/db/db_iter.cc
@@ -125,8 +125,8 @@ class DBIter: public Iterator {
   bool FindValueForCurrentKeyUsingSeek();
   void FindPrevUserKey();
   void FindNextUserKey();
-  inline void FindNextUserEntry(bool skipping);
-  void FindNextUserEntryInternal(bool skipping);
+  inline void FindNextUserEntry(bool skipping, bool prefix_check);
+  void FindNextUserEntryInternal(bool skipping, bool prefix_check);
   bool ParseKey(ParsedInternalKey* key);
   void MergeValuesNewToOld();
 
@@ -157,8 +157,9 @@ class DBIter: public Iterator {
   Statistics* statistics_;
   uint64_t max_skip_;
   const Slice* iterate_upper_bound_;
-  IterKey prefix_start_;
-  bool prefix_same_as_start_;
+  IterKey prefix_start_buf_;
+  Slice prefix_start_key_;
+  const bool prefix_same_as_start_;
 
   // No copying allowed
   DBIter(const DBIter&);
@@ -202,18 +203,13 @@ void DBIter::Next() {
     valid_ = false;
     return;
   }
-  FindNextUserEntry(true /* skipping the current user key */);
+  FindNextUserEntry(true /* skipping the current user key */, prefix_same_as_start_);
   if (statistics_ != nullptr) {
     RecordTick(statistics_, NUMBER_DB_NEXT);
     if (valid_) {
       RecordTick(statistics_, NUMBER_DB_NEXT_FOUND);
       RecordTick(statistics_, ITER_BYTES_READ, key().size() + value().size());
     }
-  }
-  if (valid_ && prefix_extractor_ && prefix_same_as_start_ &&
-      prefix_extractor_->Transform(saved_key_.GetKey())
-              .compare(prefix_start_.GetKey()) != 0) {
-    valid_ = false;
   }
 }
 
@@ -225,13 +221,18 @@ void DBIter::Next() {
 //
 // NOTE: In between, saved_key_ can point to a user key that has
 //       a delete marker
-inline void DBIter::FindNextUserEntry(bool skipping) {
+//
+// The prefix_check parameter controls whether we check the iterated
+// keys against the prefix of the seeked key. Set to false when
+// performing a seek without a key (e.g. SeekToFirst). Set to
+// prefix_same_as_start_ for other iterations.
+inline void DBIter::FindNextUserEntry(bool skipping, bool prefix_check) {
   PERF_TIMER_GUARD(find_next_user_entry_time);
-  FindNextUserEntryInternal(skipping);
+  FindNextUserEntryInternal(skipping, prefix_check);
 }
 
 // Actual implementation of DBIter::FindNextUserEntry()
-void DBIter::FindNextUserEntryInternal(bool skipping) {
+void DBIter::FindNextUserEntryInternal(bool skipping, bool prefix_check) {
   // Loop until we hit an acceptable entry to yield
   assert(iter_->Valid());
   assert(direction_ == kForward);
@@ -243,6 +244,11 @@ void DBIter::FindNextUserEntryInternal(bool skipping) {
     if (ParseKey(&ikey)) {
       if (iterate_upper_bound_ != nullptr &&
           user_comparator_->Compare(ikey.user_key, *iterate_upper_bound_) >= 0) {
+        break;
+      }
+
+      if (prefix_extractor_ && prefix_check &&
+          prefix_extractor_->Transform(ikey.user_key).compare(prefix_start_key_) != 0) {
         break;
       }
 
@@ -387,7 +393,7 @@ void DBIter::Prev() {
   }
   if (valid_ && prefix_extractor_ && prefix_same_as_start_ &&
       prefix_extractor_->Transform(saved_key_.GetKey())
-              .compare(prefix_start_.GetKey()) != 0) {
+              .compare(prefix_start_key_) != 0) {
     valid_ = false;
   }
 }
@@ -679,9 +685,15 @@ void DBIter::Seek(const Slice& target) {
 
   RecordTick(statistics_, NUMBER_DB_SEEK);
   if (iter_->Valid()) {
+    if (prefix_extractor_ && prefix_same_as_start_) {
+      prefix_start_key_ = prefix_extractor_->Transform(target);
+    }
     direction_ = kForward;
     ClearSavedValue();
-    FindNextUserEntry(false /* not skipping */);
+    FindNextUserEntry(false /* not skipping */, prefix_same_as_start_);
+    if (!valid_) {
+      prefix_start_key_.clear();
+    }
     if (statistics_ != nullptr) {
       if (valid_) {
         RecordTick(statistics_, NUMBER_DB_SEEK_FOUND);
@@ -692,7 +704,8 @@ void DBIter::Seek(const Slice& target) {
     valid_ = false;
   }
   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
-    prefix_start_.SetKey(prefix_extractor_->Transform(target));
+    prefix_start_buf_.SetKey(prefix_start_key_);
+    prefix_start_key_ = prefix_start_buf_.GetKey();
   }
 }
 
@@ -712,7 +725,7 @@ void DBIter::SeekToFirst() {
 
   RecordTick(statistics_, NUMBER_DB_SEEK);
   if (iter_->Valid()) {
-    FindNextUserEntry(false /* not skipping */);
+    FindNextUserEntry(false /* not skipping */, false /* no prefix check */);
     if (statistics_ != nullptr) {
       if (valid_) {
         RecordTick(statistics_, NUMBER_DB_SEEK_FOUND);
@@ -723,7 +736,8 @@ void DBIter::SeekToFirst() {
     valid_ = false;
   }
   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
-    prefix_start_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
+    prefix_start_buf_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
+    prefix_start_key_ = prefix_start_buf_.GetKey();
   }
 }
 
@@ -771,7 +785,8 @@ void DBIter::SeekToLast() {
     }
   }
   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
-    prefix_start_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
+    prefix_start_buf_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
+    prefix_start_key_ = prefix_start_buf_.GetKey();
   }
 }
 

--- a/internal/db/prefix_test.cc
+++ b/internal/db/prefix_test.cc
@@ -446,6 +446,10 @@ TEST_F(PrefixTest, PrefixValid) {
       iter->Next();
       ASSERT_FALSE(iter->Valid());
       ASSERT_EQ(kNotFoundResult, Get(db.get(), read_options, 12346, 8));
+
+      // Verify seeking past the prefix won't return a result.
+      SeekIterator(iter.get(), 12345, 10);
+      ASSERT_TRUE(!iter->Valid());
     }
   }
 }

--- a/iterate-upper-bound.patch
+++ b/iterate-upper-bound.patch
@@ -1,0 +1,28 @@
+From c953f0bd016ab24e05f978b12009b05f84951ef9 Mon Sep 17 00:00:00 2001
+From: Peter Mattis <petermattis@gmail.com>
+Date: Thu, 11 Feb 2016 08:30:42 -0500
+Subject: [PATCH] Use user_comparator when comparing against
+ iterate_upper_bound.
+
+See https://github.com/facebook/rocksdb/issues/983.
+See https://github.com/facebook/rocksdb/pull/984.
+---
+ internal/db/db_iter.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internal/db/db_iter.cc b/internal/db/db_iter.cc
+index 74558d5..2663d7e 100644
+--- a/internal/db/db_iter.cc
++++ b/internal/db/db_iter.cc
+@@ -242,7 +242,7 @@ void DBIter::FindNextUserEntryInternal(bool skipping) {
+ 
+     if (ParseKey(&ikey)) {
+       if (iterate_upper_bound_ != nullptr &&
+-          ikey.user_key.compare(*iterate_upper_bound_) >= 0) {
++          user_comparator_->Compare(ikey.user_key, *iterate_upper_bound_) >= 0) {
+         break;
+       }
+ 
+-- 
+2.7.1
+

--- a/prefix-same-as-start.patch
+++ b/prefix-same-as-start.patch
@@ -1,0 +1,177 @@
+From 0d3231adabba21e389f8bd56295c962ba98762eb Mon Sep 17 00:00:00 2001
+From: Peter Mattis <petermattis@gmail.com>
+Date: Thu, 28 Apr 2016 20:04:12 -0400
+Subject: [PATCH] Use prefix_same_as_start to avoid iteration in
+ FindNextUserEntryInternal.
+
+This avoids excessive iteration in tombstone fields.
+---
+ internal/db/db_iter.cc     | 53 +++++++++++++++++++++++++++++-----------------
+ internal/db/prefix_test.cc |  4 ++++
+ 2 files changed, 38 insertions(+), 19 deletions(-)
+
+diff --git a/internal/db/db_iter.cc b/internal/db/db_iter.cc
+index 2663d7e..8aed5a7 100644
+--- a/internal/db/db_iter.cc
++++ b/internal/db/db_iter.cc
+@@ -125,8 +125,8 @@ class DBIter: public Iterator {
+   bool FindValueForCurrentKeyUsingSeek();
+   void FindPrevUserKey();
+   void FindNextUserKey();
+-  inline void FindNextUserEntry(bool skipping);
+-  void FindNextUserEntryInternal(bool skipping);
++  inline void FindNextUserEntry(bool skipping, bool prefix_check);
++  void FindNextUserEntryInternal(bool skipping, bool prefix_check);
+   bool ParseKey(ParsedInternalKey* key);
+   void MergeValuesNewToOld();
+ 
+@@ -157,8 +157,9 @@ class DBIter: public Iterator {
+   Statistics* statistics_;
+   uint64_t max_skip_;
+   const Slice* iterate_upper_bound_;
+-  IterKey prefix_start_;
+-  bool prefix_same_as_start_;
++  IterKey prefix_start_buf_;
++  Slice prefix_start_key_;
++  const bool prefix_same_as_start_;
+ 
+   // No copying allowed
+   DBIter(const DBIter&);
+@@ -202,7 +203,7 @@ void DBIter::Next() {
+     valid_ = false;
+     return;
+   }
+-  FindNextUserEntry(true /* skipping the current user key */);
++  FindNextUserEntry(true /* skipping the current user key */, prefix_same_as_start_);
+   if (statistics_ != nullptr) {
+     RecordTick(statistics_, NUMBER_DB_NEXT);
+     if (valid_) {
+@@ -210,11 +211,6 @@ void DBIter::Next() {
+       RecordTick(statistics_, ITER_BYTES_READ, key().size() + value().size());
+     }
+   }
+-  if (valid_ && prefix_extractor_ && prefix_same_as_start_ &&
+-      prefix_extractor_->Transform(saved_key_.GetKey())
+-              .compare(prefix_start_.GetKey()) != 0) {
+-    valid_ = false;
+-  }
+ }
+ 
+ // PRE: saved_key_ has the current user key if skipping
+@@ -225,13 +221,18 @@ void DBIter::Next() {
+ //
+ // NOTE: In between, saved_key_ can point to a user key that has
+ //       a delete marker
+-inline void DBIter::FindNextUserEntry(bool skipping) {
++//
++// The prefix_check parameter controls whether we check the iterated
++// keys against the prefix of the seeked key. Set to false when
++// performing a seek without a key (e.g. SeekToFirst). Set to
++// prefix_same_as_start_ for other iterations.
++inline void DBIter::FindNextUserEntry(bool skipping, bool prefix_check) {
+   PERF_TIMER_GUARD(find_next_user_entry_time);
+-  FindNextUserEntryInternal(skipping);
++  FindNextUserEntryInternal(skipping, prefix_check);
+ }
+ 
+ // Actual implementation of DBIter::FindNextUserEntry()
+-void DBIter::FindNextUserEntryInternal(bool skipping) {
++void DBIter::FindNextUserEntryInternal(bool skipping, bool prefix_check) {
+   // Loop until we hit an acceptable entry to yield
+   assert(iter_->Valid());
+   assert(direction_ == kForward);
+@@ -246,6 +247,11 @@ void DBIter::FindNextUserEntryInternal(bool skipping) {
+         break;
+       }
+ 
++      if (prefix_extractor_ && prefix_check &&
++          prefix_extractor_->Transform(ikey.user_key).compare(prefix_start_key_) != 0) {
++        break;
++      }
++
+       if (ikey.sequence <= sequence_) {
+         if (skipping &&
+            user_comparator_->Compare(ikey.user_key, saved_key_.GetKey()) <= 0) {
+@@ -387,7 +393,7 @@ void DBIter::Prev() {
+   }
+   if (valid_ && prefix_extractor_ && prefix_same_as_start_ &&
+       prefix_extractor_->Transform(saved_key_.GetKey())
+-              .compare(prefix_start_.GetKey()) != 0) {
++              .compare(prefix_start_key_) != 0) {
+     valid_ = false;
+   }
+ }
+@@ -679,9 +685,15 @@ void DBIter::Seek(const Slice& target) {
+ 
+   RecordTick(statistics_, NUMBER_DB_SEEK);
+   if (iter_->Valid()) {
++    if (prefix_extractor_ && prefix_same_as_start_) {
++      prefix_start_key_ = prefix_extractor_->Transform(target);
++    }
+     direction_ = kForward;
+     ClearSavedValue();
+-    FindNextUserEntry(false /* not skipping */);
++    FindNextUserEntry(false /* not skipping */, prefix_same_as_start_);
++    if (!valid_) {
++      prefix_start_key_.clear();
++    }
+     if (statistics_ != nullptr) {
+       if (valid_) {
+         RecordTick(statistics_, NUMBER_DB_SEEK_FOUND);
+@@ -692,7 +704,8 @@ void DBIter::Seek(const Slice& target) {
+     valid_ = false;
+   }
+   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
+-    prefix_start_.SetKey(prefix_extractor_->Transform(target));
++    prefix_start_buf_.SetKey(prefix_start_key_);
++    prefix_start_key_ = prefix_start_buf_.GetKey();
+   }
+ }
+ 
+@@ -712,7 +725,7 @@ void DBIter::SeekToFirst() {
+ 
+   RecordTick(statistics_, NUMBER_DB_SEEK);
+   if (iter_->Valid()) {
+-    FindNextUserEntry(false /* not skipping */);
++    FindNextUserEntry(false /* not skipping */, false /* no prefix check */);
+     if (statistics_ != nullptr) {
+       if (valid_) {
+         RecordTick(statistics_, NUMBER_DB_SEEK_FOUND);
+@@ -723,7 +736,8 @@ void DBIter::SeekToFirst() {
+     valid_ = false;
+   }
+   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
+-    prefix_start_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
++    prefix_start_buf_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
++    prefix_start_key_ = prefix_start_buf_.GetKey();
+   }
+ }
+ 
+@@ -771,7 +785,8 @@ void DBIter::SeekToLast() {
+     }
+   }
+   if (valid_ && prefix_extractor_ && prefix_same_as_start_) {
+-    prefix_start_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
++    prefix_start_buf_.SetKey(prefix_extractor_->Transform(saved_key_.GetKey()));
++    prefix_start_key_ = prefix_start_buf_.GetKey();
+   }
+ }
+ 
+diff --git a/internal/db/prefix_test.cc b/internal/db/prefix_test.cc
+index a210e4d..f54798a 100644
+--- a/internal/db/prefix_test.cc
++++ b/internal/db/prefix_test.cc
+@@ -446,6 +446,10 @@ TEST_F(PrefixTest, PrefixValid) {
+       iter->Next();
+       ASSERT_FALSE(iter->Valid());
+       ASSERT_EQ(kNotFoundResult, Get(db.get(), read_options, 12346, 8));
++
++      // Verify seeking past the prefix won't return a result.
++      SeekIterator(iter.get(), 12345, 10);
++      ASSERT_TRUE(!iter->Valid());
+     }
+   }
+ }
+-- 
+2.7.1
+


### PR DESCRIPTION
This avoids excessive iteration in tombstone fields.
