### PR TITLE
Enable sse4.2.

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -16,4 +16,5 @@ package rocksdb
 // #cgo freebsd CXXFLAGS: -Wshorten-64-to-32
 // #cgo dragonfly CXXFLAGS: -Wshorten-64-to-32
 // #cgo windows LDFLAGS: -lrpcrt4
+// #cgo amd64 !freebsd CXXFLAGS: -msse -msse4.2
 import "C"


### PR DESCRIPTION
Except on FreeBSD, which mirrors what build_detect_platform does.

See https://github.com/cockroachdb/cockroach/issues/12992