### PR TITLE
Add a `strictld` build tag to disable ignoring symbols

### DIFF
--- a/env_platform.cc
+++ b/env_platform.cc
@@ -1,5 +1,0 @@
-#ifdef ROCKSDB_PLATFORM_POSIX
-#include "util/env_posix.cc"
-#elif OS_WIN
-#include "port/win/env_win.cc"
-#endif

--- a/import.sh
+++ b/import.sh
@@ -52,6 +52,6 @@ grep -lRF '<Rpc.h>' internal | xargs sed -i~ 's!<Rpc.h>!<rpc.h>!g'
 grep -lRF 'i64;' internal | xargs sed -i~ 's!i64;!LL;!g'
 
 # symlink so cgo compiles them
-for source_file in $(make sources | grep -vE '(/redis/|(env|port)_[a-z]+.cc$)'); do
+for source_file in $(make sources | grep -vE '^internal/(port/win|utilities/redis)/|_posix.cc$'); do
   ln -sf $source_file $(echo $source_file | sed s,/,_,g)
 done

--- a/internal/util/build_version.cc
+++ b/internal/util/build_version.cc
@@ -1,4 +1,4 @@
 #include "build_version.h"
-const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:8412f7b4bfa06e9877be9a2a423d277e2b193209";
-const char* rocksdb_build_git_date = "rocksdb_build_git_date:2017-01-28";
+const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:608bf6179ca8b317e707394d263059a933808e2f";
+const char* rocksdb_build_git_date = "rocksdb_build_git_date:2017-02-07";
 const char* rocksdb_build_compile_date = __DATE__;

--- a/internal_util_env_chroot.cc
+++ b/internal_util_env_chroot.cc
@@ -1,0 +1,1 @@
+internal/util/env_chroot.cc

--- a/internal_util_env_hdfs.cc
+++ b/internal_util_env_hdfs.cc
@@ -1,0 +1,1 @@
+internal/util/env_hdfs.cc

--- a/internal_util_io_posix.cc
+++ b/internal_util_io_posix.cc
@@ -1,1 +1,0 @@
-internal/util/io_posix.cc

--- a/internal_utilities_env_mirror.cc
+++ b/internal_utilities_env_mirror.cc
@@ -1,0 +1,1 @@
+internal/utilities/env_mirror.cc

--- a/internal_utilities_env_registry.cc
+++ b/internal_utilities_env_registry.cc
@@ -1,0 +1,1 @@
+internal/utilities/env_registry.cc

--- a/platform.cc
+++ b/platform.cc
@@ -1,0 +1,12 @@
+#ifdef OS_WIN
+#include "port/win/io_win.cc"
+#include "port/win/env_win.cc"
+#include "port/win/env_default.cc"
+#include "port/win/port_win.cc"
+#include "port/win/win_logger.cc"
+#include "port/win/xpress_win.cc"
+#else
+#include "port/port_posix.cc"
+#include "util/env_posix.cc"
+#include "util/io_posix.cc"
+#endif

--- a/port_platform.cc
+++ b/port_platform.cc
@@ -1,5 +1,0 @@
-#ifdef ROCKSDB_PLATFORM_POSIX
-#include "port/port_posix.cc"
-#elif OS_WIN
-#include "port/win/port_win.cc"
-#endif

--- a/snappy.go
+++ b/snappy.go
@@ -11,6 +11,6 @@ import (
 
 // #cgo CPPFLAGS: -DSNAPPY
 // #cgo CPPFLAGS: -I../c-snappy/internal
-// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 import "C"


### PR DESCRIPTION
Also make sure we compile all the symbols we need here; env_mirror.cc
was previously missed.